### PR TITLE
chore: update probe endpoint check

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /health
+              path: /healthy
               port: 7000
               scheme: HTTP
             periodSeconds: 10


### PR DESCRIPTION
```/health``` return a 404 