### PR TITLE
Update dead links

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -1,5 +1,5 @@
 # Deploying PDP on GCP Cloud Run
-Our PDP image runs on GCP Cloud Run without any modification. You can deploy it by using our public image on [Docker Hub](https://hub.docker.com/r/oryd/pdp).
+Our PDP image runs on GCP Cloud Run without any modification. You can deploy it by using our public image on [Docker Hub](https://hub.docker.com/r/permitio/pdp-v2).
 
 ## Step by step guide
 In the following step, we will show you how to deploy our PDP image on GCP Cloud Run,

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,5 +1,5 @@
 # Helm install
 
-1. helm repo add pdp https://permitio.github.io/sidecar
+1. ```helm repo add pdp https://permitio.github.io/PDP```
 
 2. ```helm install pdp pdp/pdp --set pdp.ApiKey=<API_KEY> --create-namespace --namespace pdp --wait```

--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -15,7 +15,7 @@ pdp_release = Release(
         version="0.0.2",
         namespace=pdp_namespace.metadata["name"],
         repository_opts=RepositoryOptsArgs(
-            repo="https://permitio.github.io/sidecar"
+            repo="https://permitio.github.io/PDP"
         ),
         values={
             "pdp": {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 resource "helm_release" "pdp" {
   name       = "pdp"
-  repository = "https://permitio.github.io/sidecar"
+  repository = "https://permitio.github.io/PDP"
   chart      = "pdp"
   version    = "0.0.2"
   namespace  = "pdp"  # Change the namespace if needed


### PR DESCRIPTION
I noticed some links in READMEs and various installation methods seemed to be out of date. Attempting to update those with live alternatives.